### PR TITLE
Add query params only if not empty

### DIFF
--- a/models/monitors_request.go
+++ b/models/monitors_request.go
@@ -15,8 +15,12 @@ type ListMonitorsQuery struct {
 
 func (q ListMonitorsQuery) ToUrlString() string {
 	params := url.Values{}
-	params.Add("url", q.URL)
-	params.Add("pronounceable_name", q.PronounceableName)
+	if q.URL != "" {
+		params.Add("url", q.URL)
+	}
+	if q.PronounceableName != "" {
+		params.Add("pronounceable_name", q.PronounceableName)
+	}
 	params.Add("per_page", strconv.Itoa(q.PerPage))
 	return params.Encode()
 }


### PR DESCRIPTION

Currently for such a request, 
```
monitors, err := bs.ListMonitors(models.ListMonitorsQuery{
		PronounceableName: "Test",
	})
```
the `RawQuery` looks like this:  `&per_page=0&pronounceable_name=Test&url=` , which makes it not possible to query using just `PronounceableName` or `URL`

With this PR, the `RawQuery` looks like: `&per_page=0&pronounceable_name=Test`