### PR TITLE
Different structs for create and update monitor

### DIFF
--- a/models/monitors_request.go
+++ b/models/monitors_request.go
@@ -29,9 +29,9 @@ type MonitorAvailabilityQuery struct {
 	To        string // Optional End date (e.g., 2021-01-27), requires `From` to be set
 }
 
-// MonitorReqBody represents request body to create a monitor
+// MonitorCreateReqBody represents request body to create a monitor
 // URL field is required, every other field is optional
-type MonitorReqBody struct {
+type MonitorCreateReqBody struct {
 	URL                 string          `json:"url"`                             // Required
 	MonitorType         string          `json:"monitor_type,omitempty"`          // defaults to `status` if empty. access valid values with MonitorTypeList
 	PronounceableName   string          `json:"pronounceable_name,omitempty"`    // name of monitor
@@ -49,6 +49,43 @@ type MonitorReqBody struct {
 	TeamWait            int             `json:"team_wait,omitempty"`             // How long to wait before escalating the incident alert to the team. Leave blank to disable escalating to the entire team. In seconds.
 	RequiredKeyword     string          `json:"required_keyword,omitempty"`      // Required if monitor_type is set to keyword or udp. We will create a new incident if this keyword is missing on your page.
 	Paused              bool            `json:"paused,omitempty"`                // Set to true to pause monitoring
+	Port                string          `json:"port,omitempty"`                  // Required if monitor_type is set to tcp, udp, smtp, pop, or imap. tcp and udp monitors accept any ports, while smtp, pop, and imap accept only the specified ports corresponding with their servers (e.g. 25,465,587 for smtp).
+	Regions             []string        `json:"regions,omitempty"`               // An array of regions to set. Allowed values are ['us', 'eu', 'as', 'au'] or any subset of these regions.
+	MonitorGroupID      string          `json:"monitor_group_id,omitempty"`      // Set this attribute if you want to add this monitor to a monitor group.
+	RecoveryPeriod      int             `json:"recovery_period,omitempty"`       // How long the monitor must be up to automatically mark an incident as resolved after being down. In seconds.
+	VerifySSL           bool            `json:"verify_ssl,omitempty"`            // verify SSL certificate validity?
+	ConfirmationPeriod  int             `json:"confirmation_period,omitempty"`   // Wait time after observing a failure before starting a new incident. In seconds.
+	HTTPMethod          string          `json:"http_method,omitempty"`           // HTTP Method used to make a request. Valid options: GET, HEAD, POST, PUT, PATCH
+	RequestTimeout      int             `json:"request_timeout,omitempty"`       // How long to wait before timing out the request. In seconds.
+	RequestBody         string          `json:"request_body,omitempty"`          // parameter1=first_value&parameter2=another_value
+	AuthUsername        string          `json:"auth_username,omitempty"`         // Basic HTTP authentication username to include with the request.
+	AuthPassword        string          `json:"auth_password,omitempty"`         // Basic HTTP authentication password to include with the request.
+	MaintenanceFrom     string          `json:"maintenance_from,omitempty"`      // Start of the maintenance window each day. We won't check your website during this window. Example: '01:00:00'
+	MaintenanceTo       string          `json:"maintenance_to,omitempty"`        // End of the maintenance window each day. Example: '03:00:00'
+	MaintenanceTimezone string          `json:"maintenance_timezone,omitempty"`  // Defaults to UTC. The accepted values can be found in the Rails TimeZone documentation. https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html
+	RememberCookies     bool            `json:"remember_cookies,omitempty"`      // keep cookies when redirecting
+	PlaywrightScript    string          `json:"playwright_script,omitempty"`     // Playwright script to run
+	ScenarioName        string          `json:"scenario_name,omitempty"`         // Name of the scenario identifying the playwright script
+}
+
+type MonitorUpdateReqBody struct {
+	URL                 string          `json:"url,omitempty"`                   // The URL of your website or the host you want to ping
+	MonitorType         string          `json:"monitor_type,omitempty"`          // defaults to `status` if empty. access valid values with MonitorTypeList
+	PronounceableName   string          `json:"pronounceable_name,omitempty"`    // name of monitor
+	Email               bool            `json:"email,omitempty"`                 // Send email alerts
+	SMS                 bool            `json:"sms,omitempty"`                   // Send sms alerts
+	Call                bool            `json:"call,omitempty"`                  // Phone call alerts
+	Push                bool            `json:"push,omitempty"`                  // Should we send a push notification to the on-call person?
+	CheckFrequency      int             `json:"check_frequency,omitempty"`       // Check frequency (in seconds)
+	RequestHeaders      []requestHeader `json:"request_headers,omitempty"`       // The request headers that will be send with the check
+	ExpectedStatusCodes []int           `json:"expected_status_codes,omitempty"` // An array of status codes you expect to receive from your website. These status codes are considered only if the monitor_type is expected_status_code.
+	DomainExpiration    int             `json:"domain_expiration,omitempty"`     // How many days before the domain expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60.
+	SSLExpiration       int             `json:"ssl_expiration,omitempty"`        // How many days before the SSL certificate expires do you want to be alerted? Valid values are 1, 2, 3, 7, 14, 30, and 60.
+	PolicyID            int             `json:"policy_id,omitempty"`             // Set the escalation policy for the monitor.
+	FollowRedirects     bool            `json:"follow_redirects,omitempty"`      // Should we automatically follow redirects when sending the HTTP request?
+	TeamWait            int             `json:"team_wait,omitempty"`             // How long to wait before escalating the incident alert to the team. Leave blank to disable escalating to the entire team. In seconds.
+	RequiredKeyword     string          `json:"required_keyword,omitempty"`      // Required if monitor_type is set to keyword or udp. We will create a new incident if this keyword is missing on your page.
+	Paused              *bool           `json:"paused,omitempty"`                // Set to true to pause monitoring
 	Port                string          `json:"port,omitempty"`                  // Required if monitor_type is set to tcp, udp, smtp, pop, or imap. tcp and udp monitors accept any ports, while smtp, pop, and imap accept only the specified ports corresponding with their servers (e.g. 25,465,587 for smtp).
 	Regions             []string        `json:"regions,omitempty"`               // An array of regions to set. Allowed values are ['us', 'eu', 'as', 'au'] or any subset of these regions.
 	MonitorGroupID      string          `json:"monitor_group_id,omitempty"`      // Set this attribute if you want to add this monitor to a monitor group.

--- a/sdk/uptime/monitors.go
+++ b/sdk/uptime/monitors.go
@@ -113,7 +113,7 @@ func (bs *Betterstack) GetAvailability(queryParams models.MonitorAvailabilityQue
 }
 
 // CreateMonitor returns a newly created monitor or validation errors.
-func (bs *Betterstack) CreateMonitor(bodyParams models.MonitorReqBody) (*models.Monitor, error) {
+func (bs *Betterstack) CreateMonitor(bodyParams models.MonitorCreateReqBody) (*models.Monitor, error) {
 	requestBody, err := json.Marshal(bodyParams)
 	if err != nil {
 		return nil, err
@@ -143,7 +143,7 @@ func (bs *Betterstack) CreateMonitor(bodyParams models.MonitorReqBody) (*models.
 }
 
 // UpdateMonitor updates existing monitor configuration. Send only the parameters you wish to change (eg. url)
-func (bs *Betterstack) UpdateMonitor(monitorID string, bodyParams models.MonitorReqBody) (*models.Monitor, error) {
+func (bs *Betterstack) UpdateMonitor(monitorID string, bodyParams models.MonitorUpdateReqBody) (*models.Monitor, error) {
 	requestBody, err := json.Marshal(bodyParams)
 	if err != nil {
 		return nil, err

--- a/sdk/uptime/test/monitors_test.go
+++ b/sdk/uptime/test/monitors_test.go
@@ -18,7 +18,7 @@ func TestListMonitors(t *testing.T) {
 }
 
 func TestCreateMonitor(t *testing.T) {
-	reqBody := models.MonitorReqBody{
+	reqBody := models.MonitorCreateReqBody{
 		URL: "https://test.com",
 	}
 	monitor, err := bs.CreateMonitor(reqBody)
@@ -76,7 +76,7 @@ func TestGetAvailability(t *testing.T) {
 }
 
 func TestUpdateMonitor(t *testing.T) {
-	reqBody := models.MonitorReqBody{
+	reqBody := models.MonitorUpdateReqBody{
 		URL: "https://test-update.com",
 	}
 	monitor, err := bs.UpdateMonitor(monitorID, reqBody)

--- a/sdk/uptime/test/status_reports_test.go
+++ b/sdk/uptime/test/status_reports_test.go
@@ -13,7 +13,7 @@ var (
 
 func TestCreateStatusPageReport(t *testing.T) {
 	monitor, err := bs.CreateMonitor(
-		models.MonitorReqBody{
+		models.MonitorCreateReqBody{
 			URL: "https://google.com",
 		},
 	)

--- a/sdk/uptime/test/status_resources_test.go
+++ b/sdk/uptime/test/status_resources_test.go
@@ -14,7 +14,7 @@ var (
 
 func TestCreateStatusPageResource(t *testing.T) {
 	monitor, err := bs.CreateMonitor(
-		models.MonitorReqBody{
+		models.MonitorCreateReqBody{
 			URL: "https://google.com",
 		},
 	)

--- a/sdk/uptime/test/status_updates_test.go
+++ b/sdk/uptime/test/status_updates_test.go
@@ -11,7 +11,7 @@ var statusUpdateID, newStatusReportID string
 
 func TestCreateStatusUpdate(t *testing.T) {
 	monitor, err := bs.CreateMonitor(
-		models.MonitorReqBody{
+		models.MonitorCreateReqBody{
 			URL: "https://google.com",
 		},
 	)


### PR DESCRIPTION
Since `URL` is not a required field while updating a monitor, I have separated the structs into create and update structs