### PR TITLE
Add maintenance_days to monitor requests and response types

### DIFF
--- a/models/monitors_request.go
+++ b/models/monitors_request.go
@@ -67,6 +67,7 @@ type MonitorCreateReqBody struct {
 	MaintenanceFrom     string          `json:"maintenance_from,omitempty"`      // Start of the maintenance window each day. We won't check your website during this window. Example: '01:00:00'
 	MaintenanceTo       string          `json:"maintenance_to,omitempty"`        // End of the maintenance window each day. Example: '03:00:00'
 	MaintenanceTimezone string          `json:"maintenance_timezone,omitempty"`  // Defaults to UTC. The accepted values can be found in the Rails TimeZone documentation. https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html
+	MaintenanceDays     []string        `json:"maintenance_days,omitempty"`      // An array of maintenance days to set. If a maintenance window is overnight both affected days should be set. Allowed values are ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] or any subset of these days.
 	RememberCookies     bool            `json:"remember_cookies,omitempty"`      // keep cookies when redirecting
 	PlaywrightScript    string          `json:"playwright_script,omitempty"`     // Playwright script to run
 	ScenarioName        string          `json:"scenario_name,omitempty"`         // Name of the scenario identifying the playwright script
@@ -104,6 +105,7 @@ type MonitorUpdateReqBody struct {
 	MaintenanceFrom     string          `json:"maintenance_from,omitempty"`      // Start of the maintenance window each day. We won't check your website during this window. Example: '01:00:00'
 	MaintenanceTo       string          `json:"maintenance_to,omitempty"`        // End of the maintenance window each day. Example: '03:00:00'
 	MaintenanceTimezone string          `json:"maintenance_timezone,omitempty"`  // Defaults to UTC. The accepted values can be found in the Rails TimeZone documentation. https://api.rubyonrails.org/classes/ActiveSupport/TimeZone.html
+	MaintenanceDays     []string        `json:"maintenance_days,omitempty"`      // An array of maintenance days to set. If a maintenance window is overnight both affected days should be set. Allowed values are ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'] or any subset of these days.
 	RememberCookies     bool            `json:"remember_cookies,omitempty"`      // keep cookies when redirecting
 	PlaywrightScript    string          `json:"playwright_script,omitempty"`     // Playwright script to run
 	ScenarioName        string          `json:"scenario_name,omitempty"`         // Name of the scenario identifying the playwright script

--- a/models/monitors_response.go
+++ b/models/monitors_response.go
@@ -41,6 +41,7 @@ type MonitorAttributes struct {
 	MaintenanceFrom     string          `json:"maintenance_from"`
 	MaintenanceTo       string          `json:"maintenance_to"`
 	MaintenanceTimezone string          `json:"maintenance_timezone"`
+	MaintenanceDays     []string        `json:"maintenance_days"`
 	Relationships       relationships   `json:"relationships"`
 	PausedAt            string          `json:"paused_at"`
 	CreatedAt           string          `json:"created_at"`


### PR DESCRIPTION
The Betterstack API supports `maintenance_days`, which is currently missing in the `monitor` `requests` and `response` `types`

This PR adds them